### PR TITLE
Now #report_data supports options passing to ignore some unwanted fields

### DIFF
--- a/lib/apir/report.rb
+++ b/lib/apir/report.rb
@@ -9,8 +9,15 @@ module Apir
       @message  = message
     end
 
-    def print_report
-      print = report.map do |k, v|
+    def print_report(options = {})
+      # find all options that match 'ignore_*' like 'ignore_response_body'
+      # and remove it from reporting
+      initial_report = report.clone
+      fields_to_remove = options.map{ |k,v| k.to_s.gsub('ignore_', '').to_sym if k.to_s.include?('ignore_') && v == true }
+
+      #  modifying initial report
+      fields_to_remove.each{ |f| initial_report.delete(f) }
+      print = initial_report.map do |k, v|
         "#{k.upcase}: '#{v}'" unless v.nil?
       end.compact.join("\r\n")
       "\r\n" + print

--- a/lib/apir/reporting.rb
+++ b/lib/apir/reporting.rb
@@ -5,8 +5,8 @@ module Apir
   # reporting module
   module Reporting
 
-    def report_data(message=nil)
-      Apir::Report.new(self, raw_response, message).print_report
+    def report_data(message=nil, options = {})
+      Apir::Report.new(self, raw_response, message).print_report(options)
     end
 
     # @return [String] request curl string

--- a/lib/apir/version.rb
+++ b/lib/apir/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Apir
-  VERSION = '0.1.5.1'
+  VERSION = '0.1.6.0'
 end


### PR DESCRIPTION
Multiple options could be passed to ignore some parts of default `#report_data`

i.e.:
```ruby
request = Apir::Request.new('http://example.com').get!
request.report_data("I don't need response body at all", ignore_response_body: true, ignore_time: true)
```